### PR TITLE
Add example of HTML buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [The notion guide is here](https://www.notion.so/Deepnote-Launch-Buttons-63c642a5e875463495ed2341e83a4b2a)
 
 ### Badge-size buttons
+
 [<img src="https://deepnote.com/buttons/launch-in-deepnote-small.svg">](https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b)
 
 [<img src="https://deepnote.com/buttons/launch-in-deepnote-white-small.svg">](https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b)
@@ -12,6 +13,7 @@
 [<img src="https://deepnote.com/buttons/try-in-a-jupyter-notebook-white-small.svg">](https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b)
 
 ### Large buttons
+
 [<img src="https://deepnote.com/buttons/launch-in-deepnote.svg">](https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b)
 
 [<img src="https://deepnote.com/buttons/launch-in-deepnote-white.svg">](https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b)
@@ -20,3 +22,10 @@
 
 [<img src="https://deepnote.com/buttons/try-in-a-jupyter-notebook-white.svg">](https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b)
 
+
+### HTML buttons
+
+<a href="https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b" target="_blank"><img src="https://deepnote.com/buttons/launch-in-deepnote-white.svg" alt="Launch in Deepnote"></a>
+
+<a href="https://deepnote.com/project/278a6f04-3419-4d21-9134-dbfb94ddb59b" target="_blank"><img src="https://deepnote.com/buttons/try-in-a-jupyter-notebook.svg" alt="Try in Jupyter Notebook"></a>
+ 


### PR DESCRIPTION
This PR includes examples of using launchpad buttons with HTML format. HTML is used in READMEs to include additional button styling.